### PR TITLE
add filter for dlllist output

### DIFF
--- a/filters/501-volatility-dlllist.conf
+++ b/filters/501-volatility-dlllist.conf
@@ -1,0 +1,52 @@
+# filter for dlllist output
+
+# This filter assumes dlllist plugin output was tagged with "volatility_dlllist"
+# on ingest.  @timestamp on the message is set to the load time.
+
+# Input:
+# "Pid","Base","Size","LoadCount","LoadTime","Path","Hostname","Investigated"
+# "4","0","0","0","","Error reading PEB for pid","DESKTOP-NBVE6KH","false"
+# "120","0","0","0","","Error reading PEB for pid","DESKTOP-NBVE6KH","false"
+# "420","1.40734E+14","1970176","65535","2019-02-13 23:33:01 UTC+0000","C:\WINDOWS\SYSTEM32\ntdll.dll","DESKTOP-NBVE6KH","false"
+
+# Output:
+# {
+#             "load_count" => 65535,
+#                   "path" => "C:\\WINDOWS\\System32\\user32.dll",
+#                    "pid" => 11664,
+#             "@timestamp" => 2019-02-15T02:04:53.000Z,
+#                   "host" => "b7f835b8fdd8",
+#                   "base" => "1.40734E+14",
+#                "message" => "\"11664\",\"1.40734E+14\",\"1638400\",\"65535\",\"2019-02-15 02:04:53 UTC+0000\",\"C:\\WINDOWS\\System32\\user32.dll\",\"DESKTOP-NBVE6KH\",\"false\"\r",
+#                   "tags" => [
+#         [0] "volatility_dlllist"
+#     ],
+#     "volhunter_hostname" => "DESKTOP-NBVE6KH",
+#           "investigated" => false,
+#               "@version" => "1",
+#                   "size" => 1638400
+# }
+
+filter {
+
+    if "volatility_dlllist" in [tags] {
+        csv {
+            source => "message"
+            skip_header => true
+            columns => [ "pid", "base", "size", 
+                         "load_count", "load_time", "path", 
+                         "volhunter_hostname", "investigated" ]
+            convert => { 
+                "pid" => "integer"
+                "size" => "integer"
+                "load_count" => "integer"
+                "investigated" => "boolean"
+            }
+        }
+
+        date {
+            match => [ "load_time", "yyyy-MM-dd HH:mm:ss 'UTC'Z" ]
+        }
+    }
+
+}


### PR DESCRIPTION
Initial filter for dlllist output.  The @timestamp on the message will be set to the load time reported by Volatility.